### PR TITLE
Fix missing dependencies with logging enabled

### DIFF
--- a/clcache/clcache_lib/clcache_lib/cl/compiler.py
+++ b/clcache/clcache_lib/clcache_lib/cl/compiler.py
@@ -429,6 +429,8 @@ def invoke_real_compiler(
             stderrFile.seek(0)
             stderr = stderrFile.read()
     else:
+        sys.stdout.flush()
+        sys.stderr.flush()
         returnCode = subprocess.call(realCmdline, env=environment)
 
     trace("Real compiler returned code {0:d}".format(returnCode))

--- a/clcache/clcache_lib/clcache_lib/utils/util.py
+++ b/clcache/clcache_lib/clcache_lib/utils/util.py
@@ -136,9 +136,9 @@ def trace(msg: str, level=1) -> None:
     if logLevel >= level:
         scriptDir = os.path.realpath(os.path.dirname(sys.argv[0]))
         with OUTPUT_LOCK:
-            print(os.path.join(scriptDir, "clcache.py") + " " + msg)
+            print(os.path.join(scriptDir, "clcache.py") + " " + msg, flush=True)
 
 
 def error(message):
     with OUTPUT_LOCK:
-        print(message, file=sys.stderr)
+        print(message, file=sys.stderr, flush=True)


### PR DESCRIPTION
I discovered an issue when clcache logging is enabled (via `CLCACHE_LOG`). When the real compiler is invoked, clcache's output may not have been fully flushed. The compiler's first line of output will be appended to wherever clcache's output was flushed up to, which can interfere with output parsing. This is notably a problem when the real compiler is invoked to show includes. The first line of compiler output is the first file included, which when appended to an incomplete clcache output line, may not be properly recorded as a dependency by the build system. I observed this failure with ninja.

My proposed changes should fix the issue in the compiler incovation case by flushing stdout and stderr before invoking the compiler. I also tried to prevent similar issues from happening elsewhere by modifying the general `trace` and `error` functions to flush their output.

These changes are untested because I'm not sure how to reintegrate the changes back into my build system. I'm hoping that you could create a build with these changes and provide it to me to test, or test it yourself.